### PR TITLE
Use result success to return error from kotlin to flutter

### DIFF
--- a/android/src/main/kotlin/com/gkco/ondato_skd/OndatoSkdPlugin.kt
+++ b/android/src/main/kotlin/com/gkco/ondato_skd/OndatoSkdPlugin.kt
@@ -48,11 +48,16 @@ class OndatoSkdPlugin : FlutterPlugin, MethodCallHandler {
         try {
             Ondato.starIdentification(mContext, object : Ondato.ResultListener {
                 override fun onSuccess(identificationId: String?) {
-                    result.success(identificationId)
+                    result.success(mapOf("identificationId" to identificationId))
                 }
 
                 override fun onFailure(identificationId: String?, error: OndatoError) {
-                    result.error(identificationId, error.name, error.message)
+                    result.success(
+                        mapOf(
+                            "identificationId" to identificationId,
+                            "error" to error.message
+                        )
+                    )
                 }
             })
         } catch (e: Exception) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -72,7 +72,7 @@ class _MyAppState extends State<MyApp> {
                               .asUint8List())),
                     ),
                   );
-                  print(await OndatoSkd.startIdentification().first);
+                  print(await OndatoSkd.startIdentification());
                 },
                 child: Text('startIdentification'),
               )

--- a/lib/ondato_skd.dart
+++ b/lib/ondato_skd.dart
@@ -19,13 +19,13 @@ class OndatoSkd {
     return _isInit;
   }
 
-  static Stream<String> startIdentification() async* {
-    Map<String, dynamic> result =
-        await _channel.invokeMethod(_OndatoSdkChannel.startIdentification);
+  static Future<String> startIdentification() async {
+    final result =
+    await _channel.invokeMethod(_OndatoSdkChannel.startIdentification);
     if (result.containsKey('error')) {
       throw OndatoException(result['identificationId'], result['error']);
     }
-    yield result['identificationId'];
+    return result['identificationId'];
   }
 }
 


### PR DESCRIPTION
`Result.error` should only be used to signal the exception thrown from the android side. And identification `failure` is just one of the results SDK might return, it should not throw the exception, therefore `result.success` is  better option to return the result from android to flutter in this case.